### PR TITLE
feat: Initial release

### DIFF
--- a/src/specs/rn-start-sdk.nitro.ts
+++ b/src/specs/rn-start-sdk.nitro.ts
@@ -30,10 +30,6 @@ export interface InitializeSdkParams {
 
 export interface RNStartIoSdk extends HybridObject<{ ios: 'swift', android: 'kotlin' }> {
     initializeSdk(params: InitializeSdkParams): void;
-    loadAd(
-        adType: AdType
-    ): Promise<void>;
-    showAd(
-        adResultCallback?: (adResult: AdResultType) => void
-    ): void;
+    loadAd(adType: AdType): Promise<void>;
+    showAd(adResultCallback?: (adResult: AdResultType) => void): void;
 }


### PR DESCRIPTION
Initial release with [Start.io](https://www.start.io/) (Formerly StartApp) `com.startapp:inapp-sdk:5.+` for Android and `StartAppSDK v4.10.5` for iOS.

feat: Interstitial Ads
    - Automatic
    - Fullscreen
    - Video
    -  Rewarded
 feat: Banner Ads
    - Basic 320 x 50
    - MRec 300 x 250
    - Cover 300 x 157 
feat: Native Ads